### PR TITLE
fix: make asset file's parent directories.

### DIFF
--- a/src/MixPugTask.js
+++ b/src/MixPugTask.js
@@ -165,13 +165,12 @@ class MixPugTask extends Task {
         let file = new File(src);
         let pathFromBase = this.relativePathFromSource(file.base(), this.excludePath);
         let baseDir = path.join(pathFromBase, this.dest);
-
-        if (!File.exists(baseDir)) {
-            new File(baseDir).makeDirectories();
-        }
-
         let output = path.join(baseDir, file.nameWithoutExtension() + this.extension);
         let asset = new File(output);
+
+        if (!File.exists(baseDir)) {
+            asset.makeDirectories();
+        }
 
         return asset;
     }


### PR DESCRIPTION
now: make asset file's grandparent directory 😿 
fixed: make asset file's parent directory 😸 